### PR TITLE
decoy file exfiltration bug fix

### DIFF
--- a/incalmo/core/actions/LowLevel/MD5SumAttackerData.py
+++ b/incalmo/core/actions/LowLevel/MD5SumAttackerData.py
@@ -25,7 +25,7 @@ class MD5SumAttackerData(LowLevelAction):
         for line in lines:
             if line == "":
                 continue
-            elif "data" in line:
+            elif "json" in line:
                 file_hash = line.split()[0]
                 filename = line.split()[1]
                 filename = os.path.basename(filename)


### PR DESCRIPTION
Previously it would only exfiltrate if the file name had the word data in it. Decoy files are named decoy_{#}, so they would not be exfiltrated at all. This fix ensures that all json files (decoy and real asset critical files) are able to be exfiltrated